### PR TITLE
README: clarify announcement procedure

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,11 @@ After the RFC is ready to go, please announce it to:
 
 - sc-dev
 - sc-users
-- scsynth.org
+- scsynth.org, under the Development category
 - Facebook (optional)
 - Slack #dev channel (optional)
+
+If you don't have an account in some of these places, someone else can do it for you if you make a request in the RFC submission.
 
 Here is a template:
 


### PR DESCRIPTION
a few minor improvements.

announcements on scsynth.org should go under "Development"; someone else can announce for you if you ask for it. these are questions that have arisen in previous RFCs.