### PR TITLE
move Wiki from Github

### DIFF
--- a/rfcs/0000-move-wiki-from-GitHub-and-host-as-static-site.md
+++ b/rfcs/0000-move-wiki-from-GitHub-and-host-as-static-site.md
@@ -1,0 +1,50 @@
+- Title: Move Wiki from GitHub and convert to a static site
+- Date proposed:2024-01-17
+- RFC PR: https://github.com/supercollider/rfcs/pull/0000 **update this number after RFC PR has been filed**
+
+# Summary
+
+Move the wiki from Github to wiki.supercollider.online.  Use [Sphinx](https://www.sphinx-doc.org/en/master/) to generate a static site.
+
+# Motivation
+
+A wiki is hopefully a permanent reference.
+
+But in the history of SC, there has already been (at least?) one abandoned wiki that was migrated to the GitHub wiki, and while GitHub is a convenient place, [it may not a place we should support.][https://sfconservancy.org/GiveUpGitHub/]
+
+Moving to out of GitHub would allow the community to take ownership of the wiki URL and be independent of the code hosting platform, providing a permanent location for precious information.
+
+This would also prepare the community/wiki in case GitHub needs to be evacuated.
+
+A static site would also have many advantages:
+- independence of any hosting platform - hosting a static website can be easily done these days
+- searching the wiki
+- editing can be performed offline
+- internal references can be checked for dead links at build time
+- custom styling
+- Clear PR workflow 
+- website structure is independent of folder structure, which allows to improve the organization of files
+
+please see discussion here: [6181](https://github.com/supercollider/supercollider/issues/6181)
+and on the forum [here](https://scsynth.org/t/the-sc-wiki/8123/11?u=semiquaver)
+
+# Specification
+
+As a proof of concept I cloned the existing wiki and converted it to a Sphinx website - this means that the history of most pages is untouched, preserving valuable git history (see https://github.com/capital-G/supercollider-wiki/blame/main/docs/contributing/workflow/Unit-Testing-Guide.md)
+
+Repo: https://github.com/capital-G/supercollider-wiki
+Website: https://capital-g.github.io/supercollider-wiki/
+
+Edit buttons were added to pages that drop users into the repo where they can edit and make pull requests in the browser.
+
+Further work on style and structure could be done using a PR workflow
+
+# Drawbacks
+
+The only drawback that surfaced in the discussions so far was relative ease of contribution. There are online wiki systems that allow users to edit directly in the browser. This proposal would limit contributors to those people comfortable with a git PR workflow. 
+
+
+
+
+# Unresolved Questions
+

--- a/rfcs/0021-move-wiki-from-GitHub-and-host-as-static-site.md
+++ b/rfcs/0021-move-wiki-from-GitHub-and-host-as-static-site.md
@@ -1,6 +1,6 @@
 - Title: Move Wiki from GitHub and convert to a static site
 - Date proposed:2024-01-17
-- RFC PR: https://github.com/supercollider/rfcs/pull/0000 **update this number after RFC PR has been filed**
+- RFC PR: https://github.com/supercollider/rfcs/pull/0021 **update this number after RFC PR has been filed**
 
 # Summary
 


### PR DESCRIPTION
## Proposal 

Move the SuperCollider Wiki from GitHub and use Sphinx to generate static site.

## Motivation

A wiki is hopefully a permanent reference.
But in the history of SC, there has already been (at least?) one abandoned wiki that was migrated to the GitHub wiki, and while GitHub is a convenient place, it [is not a place to support](https://sfconservancy.org/GiveUpGitHub/).
I therefore advocate, in support of [#6114](https://github.com/supercollider/supercollider/issues/6114), to move the current wiki <https://github.com/supercollider/supercollider/wiki> to <https://wiki.supercollider.online> and making it a repository that creates a static website, which serves as the new wiki.
This would allow to take ownership of the wiki URL and be independent of the code hosting platform, making it a permanent location for the precious information.

This would also prepare the community/wiki in case GitHub needs to be evacuated.

## Description of the proposed feature

I first thought about making a real wiki, but I think a static website is easier to maintain and has a longer lifespan.
A small wiki like SC should be suitable for a static site generator.

I decided to use [Sphinx](https://www.sphinx-doc.org/en/master/) as a static website generator because it is an established tool and has a pretty stable API (compared to NodeJS based tools).

I also don't have a clue how to contribute to the existing wiki (fork the wiki-repo and do a PR?) as I don't have editor privileges, but making it a repo would allow anyone with access to git to edit it via a PR workflow.

Sphinx would also allow to create indices, references, glossary, build local tocs, provide a search and also verify that all internal links are working during build time.

The main advantages I see

- independence of any hosting platform - hosting a static website can be easily done these days
- searching the wiki
- editing can be performed offline
- internal references can be checked for dead links at build time
- custom styling
- Clear PR workflow (how can the current wiki be edited? It has a git repo but how do I make a PR on it?)
- website structure is independent of folder structure, which allows to improve the organization of files

## Implementation plan

I cloned the existing wiki and converted it to a Sphinx website - this means that the history of most pages is untouched, preserving valuable git history (see https://github.com/capital-G/supercollider-wiki/blame/main/docs/contributing/workflow/Unit-Testing-Guide.md)

Repo: https://github.com/capital-G/supercollider-wiki
Website: https://capital-g.github.io/supercollider-wiki/

Currently hosted on GitHub pages - although this PR is motivated to evacuate GitHub, I think it is still okay to use their CI for now. The build step and serving of static content can easily be moved to e.g. GitLab.

I would be happy to take up some styling suggestions or commits, as this wiki would allow us to style and modify in such a way we want, and not how GitHub thinks it should be done.