### PR TITLE
Creation of a moderation team to enforce the Code of Conduct

### DIFF
--- a/rfcs/0000-moderation-team.md
+++ b/rfcs/0000-moderation-team.md
@@ -1,0 +1,57 @@
+- Title: Creation of a moderation team
+- Date proposed: 2024-06-16
+- RFC PR: https://github.com/supercollider/rfcs/pull/0000 **update this number after RFC PR has been filed**
+
+# Summary
+
+The [Code of Conduct](https://github.com/supercollider/supercollider/blob/develop/CODE_OF_CONDUCT.md) states that in case of an incident the *community organizers* should be contacted, but currently it is not clear who these organizers are.
+This RFC proposes to let the community decide about a team of moderators/community organizers who then are open for consultation in case of an incident.
+
+# Motivation
+
+The Code of Conduct states that a team of moderators should be contacted in case of a violation of said code, yet it is not clear
+
+- if such a team exists,
+- who these people are (are the forum moderators these moderators?),
+- how to contact them in case of an incident,
+- what *jurisdiction* they have (e.g. <scsynth.org>, github, ...) and
+- what kind of power such a council could have.
+
+Recently there have been situations which involved friction between different parties which led to violations of the code of conduct, and also to accusations against the community which **must** be taken serious.
+It therefore requires, in case such a conflict and accusation comes up, that an independent team can be consulted to evaluate the situation and take actions to de-escalate the situation and, if necessary, enforce counter-measurements based on the Code of Conduct.
+
+# Specification
+
+0. Make the forum (and community beyond) aware of this RFC in order to obtain feedback on the procedure.
+   As awareness is not targeted at a majority, this RFC would also not depend on a majority vote, but it should still be backed by a decent amount of support from within the community.
+   Once the discussion about the procedure has been settled or stalled, the first step can start.
+1. Have an open call for people who are willing to participate in such a team or council via a sticky post in the forum with a deadline of 4 weeks.
+   It should be necessary that a person gets suggested by another person as a first step of representation of trust from within the community - the person has to accept this nomination within this thread.
+   One person can nominate multiple people and is also invited to nominate an already nominated person as it can act as a relevant measurement of trust.
+
+   People are also invited in signaling that they would be interested in participating in such a team via this thread, though it would be up to the community to pick up this offer.
+
+   This is especially an invitation for people who want to contribute to SuperCollider but do not want to contribute via coding.
+2. As the forum moderators are currently a trusted set of people (?) and the closest team we have to the proposed code of conduct moderators, they should present a team from the proposed persons within two week after the deadline of the suggestions has been met.
+   An uneven number of members could avoid situations of a stalemate.
+3. Create a sticky post in the forum on how this team can be contacted and who this team is.
+   The council and forum moderators can put new people in charge, but they are advised to keep the backing from the community in mind.
+   In case of problems with this team it should be settled and discussed via the forum or via an RFC.
+
+   This council should be contacted via <scsynth.org>, but could also be in charge of conflicts happening on other platforms such as GitHub.
+
+# Drawbacks
+
+*Who watches the watchmen* is an intrinsic question of power structures - the transferring of power to this team can only happen if there is trust form the community in said council.
+In order to build trust the decisions should be as transparent as possible (upon request or via reports?) without exposing people in conflicts.
+
+The council should also represent a diverse group of people - it is up for the community and forum moderators to get these people into these positions.
+
+Also, although <scsynth.org> has become a semi-official place for SuperCollider communication, it is not a representative of the community.
+Yet, in contrast to other platforms, it is an open and community owned platform and therefore to be preferred for discussions such as creating a council.
+
+The procedure is for maybe not the very best way of doing so, but the main motivation here is to obtain such a council in order to create a safer community.
+
+# Unresolved Questions
+
+- Who creates the posts in the forum - the current moderators or the issuer of the RFC?

--- a/rfcs/0022-moderation-team.md
+++ b/rfcs/0022-moderation-team.md
@@ -1,6 +1,6 @@
 - Title: Creation of a moderation team
 - Date proposed: 2024-06-16
-- RFC PR: https://github.com/supercollider/rfcs/pull/0000 **update this number after RFC PR has been filed**
+- RFC PR: https://github.com/supercollider/rfcs/pull/22
 
 # Summary
 


### PR DESCRIPTION
- Title: Creation of a moderation team
- Date proposed: 2024-06-16
- RFC PR: https://github.com/supercollider/rfcs/pull/22

# Summary

The [Code of Conduct](https://github.com/supercollider/supercollider/blob/develop/CODE_OF_CONDUCT.md) states that in case of an incident the *community organizers* should be contacted, but currently it is not clear who these organizers are.
This RFC proposes to let the community decide about a team of moderators/community organizers who then are open for consultation in case of an incident.

# Motivation

The Code of Conduct states that a team of moderators should be contacted in case of a violation of said code, yet it is not clear

- if such a team exists,
- who these people are (are the forum moderators these moderators?),
- how to contact them in case of an incident,
- what *jurisdiction* they have (e.g. <scsynth.org>, github, ...) and
- what kind of power such a council could have.

Recently there have been situations which involved friction between different parties which led to violations of the code of conduct, and also to accusations against the community which **must** be taken serious.
It therefore requires, in case such a conflict and accusation comes up, that an independent team can be consulted to evaluate the situation and take actions to de-escalate the situation and, if necessary, enforce counter-measurements based on the Code of Conduct.

# Specification

0. Make the forum (and community beyond) aware of this RFC in order to obtain feedback on the procedure.
   As awareness is not targeted at a majority, this RFC would also not depend on a majority vote, but it should still be backed by a decent amount of support from within the community.
   Once the discussion about the procedure has been settled or stalled, the first step can start.
1. Have an open call for people who are willing to participate in such a team or council via a sticky post in the forum with a deadline of 4 weeks.
   It should be necessary that a person gets suggested by another person as a first step of representation of trust from within the community - the person has to accept this nomination within this thread.
   One person can nominate multiple people and is also invited to nominate an already nominated person as it can act as a relevant measurement of trust.

   People are also invited in signaling that they would be interested in participating in such a team via this thread, though it would be up to the community to pick up this offer.

   This is especially an invitation for people who want to contribute to SuperCollider but do not want to contribute via coding.
2. As the forum moderators are currently a trusted set of people (?) and the closest team we have to the proposed code of conduct moderators, they should present a team from the proposed persons within two week after the deadline of the suggestions has been met.
   An uneven number of members could avoid situations of a stalemate.
3. Create a sticky post in the forum on how this team can be contacted and who this team is.
   The council and forum moderators can put new people in charge, but they are advised to keep the backing from the community in mind.
   In case of problems with this team it should be settled and discussed via the forum or via an RFC.

   This council should be contacted via <scsynth.org>, but could also be in charge of conflicts happening on other platforms such as GitHub.

# Drawbacks

*Who watches the watchmen* is an intrinsic question of power structures - the transferring of power to this team can only happen if there is trust form the community in said council.
In order to build trust the decisions should be as transparent as possible (upon request or via reports?) without exposing people in conflicts.

The council should also represent a diverse group of people - it is up for the community and forum moderators to get these people into these positions.

Also, although <scsynth.org> has become a semi-official place for SuperCollider communication, it is not a representative of the community.
Yet, in contrast to other platforms, it is an open and community owned platform and therefore to be preferred for discussions such as creating a council.

The procedure is for maybe not the very best way of doing so, but the main motivation here is to obtain such a council in order to create a safer community.

# Unresolved Questions

- Who creates the posts in the forum - the current moderators or the issuer of the RFC?
